### PR TITLE
Fix missing autocomplete prop

### DIFF
--- a/src/components/region-select.vue
+++ b/src/components/region-select.vue
@@ -12,6 +12,7 @@ export default {
     regionName: Boolean,
     className: String,
     shortCodeDropdown: Boolean,
+    autocomplete: Boolean,
     placeholder: {
       type: String,
       default: 'Select Region'


### PR DESCRIPTION
This PR fixes the following `Property "autocomplete" was accessed during render but not defined on instance.` warning.

![image](https://user-images.githubusercontent.com/25065083/119673295-3f3ede80-be09-11eb-9c04-d79b21adc046.png)
