### PR TITLE
Prevent accessing $i18n during render

### DIFF
--- a/src/components/country-select.vue
+++ b/src/components/country-select.vue
@@ -54,7 +54,7 @@
             return !this.blackList.includes(country.countryShortCode)
           })
         }
-        if (this.$i18n && this.usei18n) {
+        if (this.usei18n && this.$i18n) {
           countryList = countryList.map((country) => {
             let localeCountry = Object.assign({ }, country)
             localeCountry.countryName = this.$t(country.countryName)
@@ -112,7 +112,7 @@
             return region.countryShortCode === this.firstCountry
           }
         })
-        if (this.$i18n && this.usei18n) {
+        if (this.usei18n && this.$i18n) {
           return this.$t(regionObj.countryName)
         }
         return this.shortCodeDropdown ? regionObj.countryShortCode : regionObj.countryName

--- a/src/components/region-select.vue
+++ b/src/components/region-select.vue
@@ -74,7 +74,7 @@ export default {
           return elem.countryShortCode === country
         }
       }).regions
-      if (this.$i18n && this.usei18n) {
+      if (this.usei18n && this.$i18n) {
         countryRegions = countryRegions.map((region) => {
           let localeRegion = Object.assign({}, region)
           localeRegion.name = this.$t(region.name)


### PR DESCRIPTION
Removes browser warnings, despite `useri18n` being set to false.

![Browser Warning](https://user-images.githubusercontent.com/34345789/124620694-a34acd00-deb4-11eb-92f0-97347eedf106.jpg)
